### PR TITLE
Revised script editor draw code to improve speed

### DIFF
--- a/Editor/DialogGraph.h
+++ b/Editor/DialogGraph.h
@@ -53,7 +53,7 @@ struct DialogGraph{
 		lx = 0;
 		ly = 0;
 
-		gridsize = 16;
+		gridsize = 64;
 		sel = 0;
 		selplace=-1;
 		cpos=0;
@@ -516,18 +516,18 @@ struct DialogGraph{
 
 
 		int dx,dy;
-		dx=0-vx%gridsize;
-		while(dx<w*graphzoom){
-			MoveToEx(gdc,dx,0,0);
-			LineTo(gdc,dx,h*graphzoom);
-			dx+=gridsize;
+		dx = 0 - vx % gridsize;
+		while (dx < w * graphzoom) {
+			MoveToEx(gdc, dx, 0, 0);
+			LineTo(gdc, dx, h * graphzoom);
+			dx += gridsize * graphzoom;
 		}
 
-		dy=0-vy%gridsize;
-		while(dy<h*graphzoom){
-			MoveToEx(gdc,0,dy,0);
-			LineTo(gdc,w*graphzoom,dy);
-			dy+=gridsize;
+		dy = 0 - vy % gridsize;
+		while (dy < h * graphzoom) {
+			MoveToEx(gdc, 0, dy, 0);
+			LineTo(gdc, w * graphzoom, dy);
+			dy += gridsize * graphzoom;
 		}
 
 		SelectObject(gdc,temp);
@@ -542,6 +542,26 @@ struct DialogGraph{
 		cur = nodes.head;
 		while(cur){
 			//if(cur->data->x>=0-cur->data->w && cur->data->x<=w && cur->data->y>=0-cur->data->h && cur->data->y<=h){
+			bool draw = false;
+			if (cur->data->x < -(cur->data->w) || cur->data->x < -(cur->data->y)) {
+				LLNode<DialogGraphNode*>* curBranch = cur->data->out.head;
+				while (curBranch)
+				{
+					if (curBranch->data->x >= -(cur->data->w) || curBranch->data->y >= -(cur->data->y)) {
+						draw = true;
+						break;
+					}
+					curBranch = curBranch->next;
+				}
+			}
+			else if (cur->data->x < 1920 * graphzoom && cur->data->y < 1080 * graphzoom)
+			{
+				draw = true;
+			}
+			if (!draw) {
+				cur = cur->next;
+				continue;
+			}
 				if(cur->data->selected || selgroup.find(cur->data)){
 					SelectObject(gdc,selborder);
 					SelectObject(gdc,selnode);

--- a/Editor/DialogGraphNode.h
+++ b/Editor/DialogGraphNode.h
@@ -95,200 +95,134 @@ struct DialogGraphNode{
 		sprintf(outlabel[3],l4);
 	}
 
-	void paint(HDC target){
+	void paint(HDC target) {
+		if (x < -w) {
+			DrawLines(target);
+			return;
+		}
+		if (y < -h) {
+			DrawLines(target);
+			return;
+		}
 
 		POINT points[6];
 		int i;
 
-		SetTextAlign(target,TA_CENTER);
+		SetTextAlign(target, TA_CENTER);
 
-		switch(type->shape){
-			case 0:
-				RoundRect(target,x,y,x+w,y+h,w/4,h/4);
+		switch (type->shape) {
+		case 0:
+			RoundRect(target, x, y, x + w, y + h, w / 4, h / 4);
 
 
-				for(i=0;i<4;i++){
-					if(i==argline){
-						sprintf(label[i],"%d",args[argnum]);
-					}
-					if (i==3 && GraphicsLoaded && !strcmp(type->name, "Display Shop")) {
-						TextOut(target, x + w / 4, y + 8 + i * 16, label[i], strlen(label[i]));
-					} else {
-						TextOut(target, x + w / 2, y + 8 + i * 16, label[i], strlen(label[i]));
-					}
+			for (i = 0; i < 4; i++) {
+				if (i == argline) {
+					sprintf(label[i], "%d", args[argnum]);
 				}
-				break;
-			case 1:
-				points[0].x = x+w/2;
-				points[0].y = y;
-
-				points[1].x = x;
-				points[1].y = y+h/2;
-
-				points[2].x = x+w/2;
-				points[2].y = y+h;
-
-				points[3].x = x+w;
-				points[3].y = y+h/2;
-
-				Polygon(target,points,4);
-
-				if(strlen(label[1])){
-					for(i=0;i<3;i++){
-						if(i==argline){
-							sprintf(label[i],"%d",args[argnum]);
-						}
-						TextOut(target,x+w/2,y+22+i*16,label[i],strlen(label[i]));
-					}
-				} else {
-					TextOut(target,x+w/2,y+h/2-8,label[0],strlen(label[0]));
+				if (i == 3 && GraphicsLoaded && !strcmp(type->name, "Display Shop")) {
+					TextOut(target, x + w / 4, y + 8 + i * 16, label[i], strlen(label[i]));
 				}
-				break;
-			case 2:
-				points[0].x = x;
-				points[0].y = y;
+				else {
+					TextOut(target, x + w / 2, y + 8 + i * 16, label[i], strlen(label[i]));
+				}
+			}
+			break;
+		case 1:
+			points[0].x = x + w / 2;
+			points[0].y = y;
 
-				points[1].x = x;
-				points[1].y = y+h;
+			points[1].x = x;
+			points[1].y = y + h / 2;
 
-				points[2].x = x+w;
-				points[2].y = y+h/2;
+			points[2].x = x + w / 2;
+			points[2].y = y + h;
 
-				Polygon(target,points,3);
+			points[3].x = x + w;
+			points[3].y = y + h / 2;
 
-				TextOut(target,x+w/3,y+h/2-8,label[0],strlen(label[0]));
-				break;
-			case 3:
-				Ellipse(target,x,y,x+w,y+h);
+			Polygon(target, points, 4);
 
-				TextOut(target,x+w/2,y+h/2-8,label[0],strlen(label[0]));
-				break;
-			case 4:
-				points[0].x = x + w / 2;
-				points[0].y = y;
-
-				points[1].x = x + w;
-				points[1].y = y + h * 2 / 5;
-
-				points[2].x = x + 4 * w / 5;
-				points[2].y = y + h;
-
-				points[3].x = x + 1 * w / 5;
-				points[3].y = y + h;
-
-				points[4].x = x;
-				points[4].y = y + h * 2 / 5;
-
-				Polygon(target, points, 5);
-
-				for (i = 0; i<4; i++) {
+			if (strlen(label[1])) {
+				for (i = 0; i < 3; i++) {
 					if (i == argline) {
-						if (argnum<0) {
-							sprintf(label[i], "%u %u", args[-1 * argnum - 1], args[-1 * argnum]);
-						} else {
-							sprintf(label[i], "%u", args[argnum] & 0xFF);
-						}
+						sprintf(label[i], "%d", args[argnum]);
 					}
-					TextOut(target, x + w / 2, y + 12 + i * 16, label[i], strlen(label[i]));
+					TextOut(target, x + w / 2, y + 22 + i * 16, label[i], strlen(label[i]));
 				}
-				break;
-		}
-
-		SetTextColor(target,RGB(255,255,255));
-
-		LLNode<DialogGraphNode*>*cur = out.head;
-		i=0;
-		while(cur){
-			MoveToEx(target,x+w,y+h/2,0);
-			LineTo(target,x+w+w/8,y+h/2);
-
-			if (abs(cur->data->x - x) <= 32 + 2*w && cur->data->x > x) {
-
-				LineTo(target, cur->data->x - w / 8, cur->data->y + cur->data->h / 2);
-				LineTo(target, cur->data->x, cur->data->y + cur->data->h / 2);
-
-				SetTextColor(target, RGB(0, 0, 0));
-				TextOut(target, (x + w + cur->data->x) / 2 + 1, (y + h / 2 + cur->data->y + cur->data->h / 2) / 2 - 16 + 1, outlabel[i], strlen(outlabel[i]));
-
-				SetTextColor(target, RGB(255, 255, 255));
-				TextOut(target, (x + w + cur->data->x) / 2, (y + h / 2 + cur->data->y + cur->data->h / 2) / 2 - 16, outlabel[i], strlen(outlabel[i]));
-			} else {
-
-				if (cur->data->y <= y) {
-
-					LineTo(target, x + w + w / 8, cur->data->y - h / 8);
-					LineTo(target, cur->data->x + w/2, cur->data->y - h / 8);
-					LineTo(target, cur->data->x + w/2, cur->data->y);
-
-
-					SetTextColor(target, RGB(0, 0, 0));
-					TextOut(target, (x + w + cur->data->x) / 2 + 1, cur->data->y - h / 8 - 8 + 1, outlabel[i], strlen(outlabel[i]));
-
-					SetTextColor(target, RGB(255, 255, 255));
-					TextOut(target, (x + w + cur->data->x) / 2, cur->data->y - h / 8 - 8, outlabel[i], strlen(outlabel[i]));
-
-				} else {
-
-					LineTo(target, x + w + w / 8, cur->data->y + h + h / 8);
-					LineTo(target, cur->data->x + w / 2, cur->data->y + h + h / 8);
-					LineTo(target, cur->data->x + w / 2, cur->data->y + h);
-
-
-					SetTextColor(target, RGB(0, 0, 0));
-					TextOut(target, (x + w + cur->data->x) / 2 + 1, cur->data->y + h + h / 8 - 8 + 1, outlabel[i], strlen(outlabel[i]));
-
-					SetTextColor(target, RGB(255, 255, 255));
-					TextOut(target, (x + w + cur->data->x) / 2, cur->data->y + h + h / 8 - 8, outlabel[i], strlen(outlabel[i]));
-
-				}
-
 			}
-			cur=cur->next;
-			i=i+1;
-		}
-
-		SetTextColor(target,RGB(0,0,0));
-
-		SetTextAlign(target,TA_LEFT);
-
-		if(selected&&type->shape!=3){
-			Rectangle(target,x+w-10,y+h/2-5,x+w,y+h/2+5);
-			if(selout){
-				MoveToEx(target,x+w,y+h/2,0);
-				LineTo(target,x+w+w/8,y+h/2);
-
-				LineTo(target,x+ox-w/8,y+oy);
-				LineTo(target,x+ox,y+oy);
-
-				int no;
-
-				if (out.size<type->numout) {
-					no = out.size;
-				} else {
-					no = type->numout - 1;
-					if (no > 0 && (GetKeyState(VK_SHIFT) & 0x80))no--;
-				}
-
-				SetTextColor(target, RGB(0, 0, 0));
-				TextOut(target, (2 * x + w + ox) / 2 + 1, (2 * y + h / 2 + oy) / 2 - 16 + 1, outlabel[no], strlen(outlabel[no]));
-				SetTextColor(target, RGB(255, 255, 255));
-				TextOut(target, (2 * x + w + ox) / 2, (2 * y + h / 2 + oy) / 2 - 16, outlabel[no], strlen(outlabel[no]));
-				SetTextColor(target, RGB(0, 0, 0));
+			else {
+				TextOut(target, x + w / 2, y + h / 2 - 8, label[0], strlen(label[0]));
 			}
+			break;
+		case 2:
+			points[0].x = x;
+			points[0].y = y;
+
+			points[1].x = x;
+			points[1].y = y + h;
+
+			points[2].x = x + w;
+			points[2].y = y + h / 2;
+
+			Polygon(target, points, 3);
+
+			TextOut(target, x + w / 3, y + h / 2 - 8, label[0], strlen(label[0]));
+			break;
+		case 3:
+			Ellipse(target, x, y, x + w, y + h);
+
+			TextOut(target, x + w / 2, y + h / 2 - 8, label[0], strlen(label[0]));
+			break;
+		case 4:
+			points[0].x = x + w / 2;
+			points[0].y = y;
+
+			points[1].x = x + w;
+			points[1].y = y + h * 2 / 5;
+
+			points[2].x = x + 4 * w / 5;
+			points[2].y = y + h;
+
+			points[3].x = x + 1 * w / 5;
+			points[3].y = y + h;
+
+			points[4].x = x;
+			points[4].y = y + h * 2 / 5;
+
+			Polygon(target, points, 5);
+
+			for (i = 0; i < 4; i++) {
+				if (i == argline) {
+					if (argnum < 0) {
+						sprintf(label[i], "%u %u", args[-1 * argnum - 1], args[-1 * argnum]);
+					}
+					else {
+						sprintf(label[i], "%u", args[argnum] & 0xFF);
+					}
+				}
+				TextOut(target, x + w / 2, y + 12 + i * 16, label[i], strlen(label[i]));
+			}
+			break;
 		}
+
+		SetTextColor(target, RGB(255, 255, 255));
+
+		DrawLines(target);
 
 		if (GraphicsLoaded && !strcmp(type->name, "Set Portrait")) {
 			int m = args[0];
 			int width = POSize[m][0];
 			int height = POSize[m][1];
 
-			for (int px = 0;px<width*3/4;px++) {
-				for (int py = 0;py<height;py++) {
+			int threeQuarters = width * 3 / 4;
+			int oneQuarter = threeQuarters / 3;
+			for (int px = 0; px < threeQuarters; px++) {
+				for (int py = oneQuarter; py < threeQuarters; py++) {
 
-					int k = Portraits[m][px + py*width];
-					if (k<0)k = 0;
+					int k = Portraits[m][px + py * width];
+					if (k < 0)k = 0;
 
-					SetPixel(target, x+px+16, y+py+8, RGB(POPalette[m][k][0], POPalette[m][k][1], POPalette[m][k][2]));
+					SetPixel(target, x + px + 16, y + py + 8, RGB(POPalette[m][k][0], POPalette[m][k][1], POPalette[m][k][2]));
 
 				}
 			}
@@ -296,25 +230,25 @@ struct DialogGraphNode{
 
 		if (GraphicsLoaded && !strcmp(type->name, "Set Sprite Direction")) {
 
-			for (int px = 0;px < 48 / 2;px++) {
-				for (int py = 0;py < 24;py++) {
+			for (int px = 0; px < 48 / 2; px++) {
+				for (int py = 0; py < 24; py++) {
 					int k;
 					switch (args[1]) {
-						case 0:
-							k = MapSprites[0][2][px + py * 48];
-							break;
-						case 2:
-							k = MapSprites[0][0][px + py * 48];
-							break;
-						case 3:
-							k = MapSprites[0][1][px + py * 48];
-							break;
-						case 1:
-							k = MapSprites[0][1][24 - px + py * 48];
-							break;
+					case 0:
+						k = MapSprites[0][2][px + py * 48];
+						break;
+					case 2:
+						k = MapSprites[0][0][px + py * 48];
+						break;
+					case 3:
+						k = MapSprites[0][1][px + py * 48];
+						break;
+					case 1:
+						k = MapSprites[0][1][24 - px + py * 48];
+						break;
 					}
 					if (k < 0)k = 0;
-					if(k)SetPixel(target, x+px + 28, y+py + 52, RGB(FMSPalette[k][0], FMSPalette[k][1], FMSPalette[k][2]));
+					if (k)SetPixel(target, x + px + 28, y + py + 52, RGB(FMSPalette[k][0], FMSPalette[k][1], FMSPalette[k][2]));
 				}
 			}
 		}
@@ -336,15 +270,102 @@ struct DialogGraphNode{
 			for (int px = 0; px < 48 / 2; px++) {
 				for (int py = 0; py < 24; py++) {
 					int k;
-					if(ShopTypes[args[0]])k = MapSprites[132][0][px + py * 48];
+					if (ShopTypes[args[0]])k = MapSprites[132][0][px + py * 48];
 					else k = MapSprites[130][0][px + py * 48];
 
 					if (k < 0)k = 0;
-					if (k)SetPixel(target, x + px + 28 + w/4, y + py + 52, RGB(FMSPalette[k][0], FMSPalette[k][1], FMSPalette[k][2]));
+					if (k)SetPixel(target, x + px + 28 + w / 4, y + py + 52, RGB(FMSPalette[k][0], FMSPalette[k][1], FMSPalette[k][2]));
 				}
 			}
 		}
 
+	}
+
+	void DrawLines(const HDC& target)
+	{
+		LLNode<DialogGraphNode*>* cur = out.head;
+		int i = 0;
+		while (cur) {
+			MoveToEx(target, x + w, y + h / 2, 0);
+			LineTo(target, x + w + w / 8, y + h / 2);
+
+			if (abs(cur->data->x - x) <= 32 + 2 * w && cur->data->x > x) {
+
+				LineTo(target, cur->data->x - w / 8, cur->data->y + cur->data->h / 2);
+				LineTo(target, cur->data->x, cur->data->y + cur->data->h / 2);
+
+				SetTextColor(target, RGB(0, 0, 0));
+				TextOut(target, (x + w + cur->data->x) / 2 + 1, (y + h / 2 + cur->data->y + cur->data->h / 2) / 2 - 16 + 1, outlabel[i], strlen(outlabel[i]));
+
+				SetTextColor(target, RGB(255, 255, 255));
+				TextOut(target, (x + w + cur->data->x) / 2, (y + h / 2 + cur->data->y + cur->data->h / 2) / 2 - 16, outlabel[i], strlen(outlabel[i]));
+			}
+			else {
+
+				if (cur->data->y <= y) {
+
+					LineTo(target, x + w + w / 8, cur->data->y - h / 8);
+					LineTo(target, cur->data->x + w / 2, cur->data->y - h / 8);
+					LineTo(target, cur->data->x + w / 2, cur->data->y);
+
+
+					SetTextColor(target, RGB(0, 0, 0));
+					TextOut(target, (x + w + cur->data->x) / 2 + 1, cur->data->y - h / 8 - 8 + 1, outlabel[i], strlen(outlabel[i]));
+
+					SetTextColor(target, RGB(255, 255, 255));
+					TextOut(target, (x + w + cur->data->x) / 2, cur->data->y - h / 8 - 8, outlabel[i], strlen(outlabel[i]));
+
+				}
+				else {
+
+					LineTo(target, x + w + w / 8, cur->data->y + h + h / 8);
+					LineTo(target, cur->data->x + w / 2, cur->data->y + h + h / 8);
+					LineTo(target, cur->data->x + w / 2, cur->data->y + h);
+
+
+					SetTextColor(target, RGB(0, 0, 0));
+					TextOut(target, (x + w + cur->data->x) / 2 + 1, cur->data->y + h + h / 8 - 8 + 1, outlabel[i], strlen(outlabel[i]));
+
+					SetTextColor(target, RGB(255, 255, 255));
+					TextOut(target, (x + w + cur->data->x) / 2, cur->data->y + h + h / 8 - 8, outlabel[i], strlen(outlabel[i]));
+
+				}
+
+			}
+			cur = cur->next;
+			i = i + 1;
+		}
+
+		SetTextColor(target, RGB(0, 0, 0));
+
+		SetTextAlign(target, TA_LEFT);
+
+		if (selected && type->shape != 3) {
+			Rectangle(target, x + w - 10, y + h / 2 - 5, x + w, y + h / 2 + 5);
+			if (selout) {
+				MoveToEx(target, x + w, y + h / 2, 0);
+				LineTo(target, x + w + w / 8, y + h / 2);
+
+				LineTo(target, x + ox - w / 8, y + oy);
+				LineTo(target, x + ox, y + oy);
+
+				int no;
+
+				if (out.size < type->numout) {
+					no = out.size;
+				}
+				else {
+					no = type->numout - 1;
+					if (no > 0 && (GetKeyState(VK_SHIFT) & 0x80))no--;
+				}
+
+				SetTextColor(target, RGB(0, 0, 0));
+				TextOut(target, (2 * x + w + ox) / 2 + 1, (2 * y + h / 2 + oy) / 2 - 16 + 1, outlabel[no], strlen(outlabel[no]));
+				SetTextColor(target, RGB(255, 255, 255));
+				TextOut(target, (2 * x + w + ox) / 2, (2 * y + h / 2 + oy) / 2 - 16, outlabel[no], strlen(outlabel[no]));
+				SetTextColor(target, RGB(0, 0, 0));
+			}
+		}
 	}
 
 	void click(int px, int py){


### PR DESCRIPTION
- Nodes are now only drawn within a currently visible 1920x1080px area
   * TODO: Respect window size rather than hard values
- Gridline spacing made less frequent and modified by zoom level
- Portrait nodes draw only a section of the portrait
   * TODO: Find out if there is a faster way to allow drawing full portraits